### PR TITLE
Fix/fix getText parameter

### DIFF
--- a/tests/pages/BookPageCounts.test.ts
+++ b/tests/pages/BookPageCounts.test.ts
@@ -1,0 +1,34 @@
+import { vi, describe, it, expect } from 'vitest'
+
+declare global {
+  interface Window {
+    __VITEST__?: boolean
+  }
+}
+import { render, waitFor } from '@testing-library/svelte'
+import BookPage from '$lib/pages/BookPage.svelte'
+
+describe('BookPage initial telemetry counts', () => {
+  it('omits counts (null) on first load', async () => {
+    ;(window as unknown as { __VITEST__?: boolean }).__VITEST__ = true
+    // Minimal RequestInfo fallback type for tests (avoid DOM lib dependency)
+    type Req = string | URL
+    const fetchMock = vi.fn(async (input: Req) => {
+      const url = String(input)
+      if (url.includes('/text')) {
+        const u = new URL(url)
+        expect(u.searchParams.get('wordClickCount')).toBeNull()
+        expect(u.searchParams.get('sentenceClickCount')).toBeNull()
+        return new Response(JSON.stringify({ rate: null, endSentenceNo: 0, text: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response('{}', { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    render(BookPage, { bookId: 'test' })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled(), { timeout: 1500 })
+  })
+})

--- a/tests/pages/BookPageTelemetry.test.ts
+++ b/tests/pages/BookPageTelemetry.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+
+declare global {
+  interface Window {
+    __VITEST__?: boolean
+    __bookPageForceNext?: () => void
+  }
+}
+import { render, waitFor } from '@testing-library/svelte'
+import BookPage from '$lib/pages/BookPage.svelte'
+
+// Helper to parse URL params
+function getParam(url: string, key: string) {
+  const u = new URL(url)
+  return u.searchParams.get(key)
+}
+
+describe('BookPage telemetry first vs subsequent loads', () => {
+  it('sends null counts first then zero on second page load with no interactions', async () => {
+    ;(window as unknown as { __VITEST__?: boolean; __bookPageForceNext?: () => void }).__VITEST__ =
+      true
+    let callIndex = 0
+    type Req = string | URL
+    vi.stubGlobal('fetch', (input: Req) => {
+      const url = String(input)
+      if (url.includes('/text')) {
+        callIndex++
+        const word = getParam(url, 'wordClickCount')
+        const sentence = getParam(url, 'sentenceClickCount')
+        if (callIndex === 1) {
+          // first load -> null omitted from query (should be absent)
+          expect(word).toBeNull()
+          expect(sentence).toBeNull()
+        } else if (callIndex === 2) {
+          // second load, no clicks performed -> should send 0
+          expect(word).toBe('0')
+          expect(sentence).toBe('0')
+        }
+        // Return at least one sentence so lastEnd updates and second load param changes
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              rate: null,
+              endSentenceNo: callIndex * 10,
+              text: [
+                { type: 'text', sentenceNo: callIndex * 10 - 9, en: 'Hello world ' + callIndex },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        ) as Promise<Response>
+      }
+      return Promise.resolve(new Response('{}', { status: 200 })) as Promise<Response>
+    })
+
+    render(BookPage, { bookId: 'telemetry' })
+    // wait for first load
+    await waitFor(() => expect(callIndex).toBe(1), { timeout: 1500 })
+    // trigger a second load via test hook
+    ;(window as unknown as { __bookPageForceNext?: () => void }).__bookPageForceNext?.()
+    await waitFor(() => expect(callIndex).toBeGreaterThanOrEqual(2), { timeout: 1500 })
+  })
+})


### PR DESCRIPTION
# プルリクエスト

## 概要

getTextで文字や文を選択していない場合nullとしてparameterがincludeされていない。
0でもincludeされるように修正

## 関連 Issue

Fixes: #19 

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] ドキュメント
- [ ] リファクタリング

## テスト方法

Vitestでintegration testと動作確認済み

## チェックリスト

- [ ] コードはスタイルガイドに準拠している -> fix in #17 
- [x] 自己レビューを実施した
- [x] コメント/ドキュメントを追加した
